### PR TITLE
Fix OnChanged events in .Net Core by increasing variable scope

### DIFF
--- a/Gibe.CacheBusting/ManifestFile.cs
+++ b/Gibe.CacheBusting/ManifestFile.cs
@@ -11,6 +11,7 @@ namespace Gibe.CacheBusting
 		private readonly IFileService _fileService;
 		private readonly string _path;
 		private readonly string _sourceFile;
+		private FileSystemWatcher _fsw;
 
 		public event EventHandler Changed;
 
@@ -25,13 +26,13 @@ namespace Gibe.CacheBusting
 
 		private void WatchManifestForChanges(string file)
 		{
-			var fsw = new FileSystemWatcher(Path.GetDirectoryName(file), Path.GetFileName(file))
+			_fsw = new FileSystemWatcher(Path.GetDirectoryName(file), Path.GetFileName(file))
 			{
 				NotifyFilter = NotifyFilters.LastWrite
 			};
-			fsw.Created += (sender, args) => OnChanged(args);
-			fsw.Changed += (sender, args) => OnChanged(args);
-			fsw.EnableRaisingEvents = true;
+			_fsw.Created += (sender, args) => OnChanged(args);
+			_fsw.Changed += (sender, args) => OnChanged(args);
+			_fsw.EnableRaisingEvents = true;
 		}
 
 		public Dictionary<string, string> GetManifest()

--- a/Gibe.CacheBusting/RevisionManifest.cs
+++ b/Gibe.CacheBusting/RevisionManifest.cs
@@ -9,6 +9,7 @@ namespace Gibe.CacheBusting
 	{
 		private readonly IManifestFileFactory _manifestFileFactory;
 		private Dictionary<string, string> _lookup;
+		private IEnumerable<ManifestFile> _files;
 
 
 #if NETFULL
@@ -58,15 +59,15 @@ namespace Gibe.CacheBusting
 			if (_lookup == null)
 			{
 				_lookup = new Dictionary<string, string>();
-				var files = _manifestFileFactory.GetManifestFiles().ToArray();
-				foreach (var file in files)
+				_files = _manifestFileFactory.GetManifestFiles().ToArray();
+				foreach (var file in _files)
 				{
 					foreach (var kvp in file.GetManifest())
 					{
 						_lookup.Add(kvp.Key, kvp.Value);
 					}
 				}
-				WatchFilesForChanges(files);
+				WatchFilesForChanges(_files);
 			}
 			return _lookup;
 		}
@@ -75,8 +76,13 @@ namespace Gibe.CacheBusting
 		{
 			foreach (var file in files)
 			{
-				file.Changed += (s, e) => _lookup = null;
+				file.Changed += (s, e) => OnChanged();
 			}
+		}
+
+		private void OnChanged() {
+			_lookup = null;
+			_files = null;
 		}
 	}
 }


### PR DESCRIPTION
Fix an error in Umbraco 9 where rev-manifest OnChanged events were not triggering, by increasing the scope of the FileSystemWatcher & loaded manifest files, therefore allowing OnChanged events to persist.